### PR TITLE
feat: improve documentation and refactor Maven properties

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -36,6 +36,7 @@
   </scm>
 
   <properties>
+    <jacoco.version>0.8.14</jacoco.version>
     <maven.compiler.release>25</maven.compiler.release>
     <organization.url>https://mangila.github.io/ensure4j</organization.url>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -193,7 +194,7 @@
         <!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.14</version>
+        <version>${jacoco.version}</version>
         <executions>
           <execution>
             <goals>
@@ -275,7 +276,7 @@
         <!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.14</version>
+        <version>${jacoco.version}</version>
       </plugin>
     </plugins>
   </reporting>

--- a/lib/src/main/java/io/github/mangila/ensure4j/Ensure.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/Ensure.java
@@ -24,6 +24,8 @@ public final class Ensure {
   }
 
   /**
+   * Get the array operations.
+   *
    * @see EnsureArrayOps
    */
   @NonNull
@@ -32,6 +34,8 @@ public final class Ensure {
   }
 
   /**
+   * Get the collection operations.
+   *
    * @see EnsureCollectionOps
    */
   @NonNull
@@ -40,6 +44,8 @@ public final class Ensure {
   }
 
   /**
+   * Get the map operations.
+   *
    * @see EnsureMapOps
    */
   @NonNull
@@ -48,6 +54,8 @@ public final class Ensure {
   }
 
   /**
+   * Get the number operations.
+   *
    * @see EnsureNumberOps
    */
   @NonNull
@@ -56,6 +64,8 @@ public final class Ensure {
   }
 
   /**
+   * Get the object operations.
+   *
    * @see EnsureObjectOps
    */
   @NonNull
@@ -64,6 +74,8 @@ public final class Ensure {
   }
 
   /**
+   * Get the string operations.
+   *
    * @see EnsureStringOps
    */
   @NonNull
@@ -72,6 +84,14 @@ public final class Ensure {
   }
 
   /**
+   * Returns the provided object if it is not null; otherwise, it evaluates and returns the result
+   * from the supplied {@link Supplier}.
+   *
+   * @param <T> the type of the object
+   * @param object the object to check for non-nullity
+   * @param fallbackSupplier the supplier to provide an alternative object if {@code object} is null
+   * @return the non-null {@code object}, or the value provided by the {@code fallbackSupplier}
+   * @throws EnsureException if the {@code fallbackSupplier} is null or produces a null value
    * @see EnsureNullOps#notNullOrElseGet(Object, Supplier)
    */
   public static <T> T notNullOrElseGet(T object, Supplier<T> fallbackSupplier)
@@ -80,6 +100,13 @@ public final class Ensure {
   }
 
   /**
+   * Ensures that the specified object is not null. If the object is null, the default object is
+   * returned.
+   *
+   * @param <T> the type of the object
+   * @param object the object to check for nullity
+   * @param defaultObject the default object to return if {@code object} is null
+   * @return {@code object} if it is not null, otherwise {@code defaultObject}
    * @see EnsureNullOps#notNullOrElse(Object, Object)
    */
   public static <T> T notNullOrElse(T object, T defaultObject) {
@@ -105,22 +132,44 @@ public final class Ensure {
   }
 
   /**
+   * Ensures that the provided object is not null.
+   *
+   * @param <T> the type of the object
+   * @param object the object to check
+   * @param exceptionSupplier the supplier that provides the exception to be thrown if validation
+   *     fails
+   * @return the provided object if it is not null
+   * @throws RuntimeException if the object is null; the thrown exception is provided by {@code
+   *     exceptionSupplier}
    * @see EnsureNullOps#notNull(Object, Supplier)
    */
-  public static <T> T notNull(
-      T object, Supplier<? extends RuntimeException> runtimeExceptionSupplier)
+  public static <T> T notNull(T object, Supplier<? extends RuntimeException> exceptionSupplier)
       throws RuntimeException {
-    return NULL_OPS.notNull(object, runtimeExceptionSupplier);
+    return NULL_OPS.notNull(object, exceptionSupplier);
   }
 
   /**
+   * Ensures that the provided object is not null.
+   *
+   * @param <T> the type of the object
+   * @param object the object to check
+   * @param exceptionMessage the message to include in the exception if validation fails
+   * @return the provided object if it is not null
+   * @throws EnsureException if the object is null, with the provided message
    * @see EnsureNullOps#notNull(Object, String)
    */
-  public static <T> T notNull(T object, String message) throws EnsureException {
-    return NULL_OPS.notNull(object, message);
+  public static <T> T notNull(T object, String exceptionMessage) throws EnsureException {
+    return NULL_OPS.notNull(object, exceptionMessage);
   }
 
   /**
+   * Ensures that the provided object is not null.
+   *
+   * @param <T> the type of the object
+   * @param object the object to check
+   * @return the provided object if it is not null
+   * @throws EnsureException if the object is null, with the message {@code "object must not be
+   *     null"}
    * @see EnsureNullOps#notNull(Object)
    */
   public static <T> T notNull(T object) throws EnsureException {
@@ -128,15 +177,27 @@ public final class Ensure {
   }
 
   /**
+   * Ensures that the provided boolean value is true.
+   *
+   * @param expression the boolean value to check
+   * @param exceptionSupplier the supplier that provides the exception to be thrown if validation
+   *     fails
+   * @throws RuntimeException if the boolean value is false; the thrown exception is provided by
+   *     {@code exceptionSupplier}
    * @see EnsureBooleanOps#isTrue(boolean, Supplier)
    */
   public static void isTrue(
-      boolean expression, Supplier<? extends RuntimeException> runtimeExceptionSupplier)
+      boolean expression, Supplier<? extends RuntimeException> exceptionSupplier)
       throws RuntimeException {
-    BOOLEAN_OPS.isTrue(expression, runtimeExceptionSupplier);
+    BOOLEAN_OPS.isTrue(expression, exceptionSupplier);
   }
 
   /**
+   * Ensures that the provided boolean value is true.
+   *
+   * @param expression the boolean value to check
+   * @param exceptionMessage the message to include in the exception if validation fails
+   * @throws EnsureException if the boolean value is false, with the provided message
    * @see EnsureBooleanOps#isTrue(boolean, String)
    */
   public static void isTrue(boolean expression, String exceptionMessage) throws EnsureException {
@@ -144,6 +205,11 @@ public final class Ensure {
   }
 
   /**
+   * Ensures that the provided boolean value is true.
+   *
+   * @param expression the boolean value to check
+   * @throws EnsureException if the boolean value is false, with the message {@code "boolean must be
+   *     true"}
    * @see EnsureBooleanOps#isTrue(boolean)
    */
   public static void isTrue(boolean expression) throws EnsureException {
@@ -151,15 +217,27 @@ public final class Ensure {
   }
 
   /**
+   * Ensures that the provided boolean value is false.
+   *
+   * @param expression the boolean value to check
+   * @param exceptionSupplier the supplier that provides the exception to be thrown if validation
+   *     fails
+   * @throws RuntimeException if the boolean value is true; the thrown exception is provided by
+   *     {@code exceptionSupplier}
    * @see EnsureBooleanOps#isFalse(boolean, Supplier)
    */
   public static void isFalse(
-      boolean expression, Supplier<? extends RuntimeException> runtimeExceptionSupplier)
+      boolean expression, Supplier<? extends RuntimeException> exceptionSupplier)
       throws RuntimeException {
-    BOOLEAN_OPS.isFalse(expression, runtimeExceptionSupplier);
+    BOOLEAN_OPS.isFalse(expression, exceptionSupplier);
   }
 
   /**
+   * Ensures that the provided boolean value is false.
+   *
+   * @param expression the boolean value to check
+   * @param exceptionMessage the message to include in the exception if validation fails
+   * @throws EnsureException if the boolean value is true, with the provided message
    * @see EnsureBooleanOps#isFalse(boolean, String)
    */
   public static void isFalse(boolean expression, String exceptionMessage) throws EnsureException {
@@ -167,6 +245,11 @@ public final class Ensure {
   }
 
   /**
+   * Ensures that the provided boolean value is false.
+   *
+   * @param expression the boolean value to check
+   * @throws EnsureException if the boolean value is true, with the message {@code "boolean must be
+   *     false"}
    * @see EnsureBooleanOps#isFalse(boolean)
    */
   public static void isFalse(boolean expression) throws EnsureException {

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureArrayOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureArrayOps.java
@@ -11,6 +11,10 @@ import java.util.function.Supplier;
  * singleton behavior, ensuring a single instance is used throughout.
  */
 public enum EnsureArrayOps {
+  /**
+   * Access point for the {@code EnsureArrayOps} singleton. Use this instance to perform array
+   * operations.
+   */
   INSTANCE;
 
   /**

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureBooleanOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureBooleanOps.java
@@ -10,6 +10,11 @@ import java.util.function.Supplier;
  * behavior, ensuring a single instance is used throughout.
  */
 public enum EnsureBooleanOps {
+
+  /**
+   * Access point for the {@code EnsureBooleanOps} singleton. Use this instance to perform boolean
+   * operations.
+   */
   INSTANCE;
 
   /**

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureCollectionOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureCollectionOps.java
@@ -12,6 +12,11 @@ import java.util.function.Supplier;
  * singleton behavior, ensuring a single instance is used throughout.
  */
 public enum EnsureCollectionOps {
+
+  /**
+   * Access point for the {@code EnsureCollectionOps} singleton. Use this instance to perform
+   * collection operations.
+   */
   INSTANCE;
 
   /**

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureMapOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureMapOps.java
@@ -12,6 +12,11 @@ import java.util.function.Supplier;
  * behavior, ensuring a single instance is used throughout.
  */
 public enum EnsureMapOps {
+
+  /**
+   * Access point for the {@code EnsureMapOps} singleton. Use this instance to perform map
+   * operations.
+   */
   INSTANCE;
 
   /**

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureNullOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureNullOps.java
@@ -11,10 +11,16 @@ import java.util.function.Supplier;
  * behavior, ensuring a single instance is used throughout.
  */
 public enum EnsureNullOps {
+
+  /**
+   * Access point for the {@code EnsureNullOps} singleton. Use this instance to perform null
+   * operations.
+   */
   INSTANCE;
 
   /**
-   * Returns the provided object if it is not null; otherwise, returns the given default object.
+   * Ensures that the specified object is not null. If the object is null, the default object is
+   * returned.
    *
    * @param <T> the type of the object
    * @param object the object to check for nullity

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureNumberOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureNumberOps.java
@@ -10,6 +10,11 @@ import java.util.function.Supplier;
  * behavior, ensuring a single instance is used throughout.
  */
 public enum EnsureNumberOps {
+
+  /**
+   * Access point for the {@code EnsureNumberOps} singleton. Use this instance to perform number
+   * operations.
+   */
   INSTANCE;
 
   /**

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureObjectOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureObjectOps.java
@@ -12,6 +12,11 @@ import java.util.function.Supplier;
  * behavior, ensuring a single instance is used throughout.
  */
 public enum EnsureObjectOps {
+
+  /**
+   * Access point for the {@code EnsureObjectOps} singleton. Use this instance to perform object
+   * operations.
+   */
   INSTANCE;
 
   /**

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureStringOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureStringOps.java
@@ -10,6 +10,11 @@ import java.util.function.Supplier;
  * behavior, ensuring a single instance is used throughout.
  */
 public enum EnsureStringOps {
+
+  /**
+   * Access point for the {@code EnsureStringOps} singleton. Use this instance to perform string
+   * operations.
+   */
   INSTANCE;
 
   /**


### PR DESCRIPTION
- Added Javadoc comments to singleton instances and methods in `Ensure` and various `Ops` classes.
- Simplified `jacoco` plugin configurations in `pom.xml` with a centralized property.