### PR TITLE
ci: update GitHub Actions workflows to use latest action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - name: Checkout
         # https://github.com/actions/checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      # Setup Java
+
       - name: Setup Java
         # https://github.com/actions/setup-java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: 'zulu'
@@ -32,7 +32,7 @@ jobs:
           server-username: SONAR_USERNAME
           server-password: SONAR_PASSWORD
           cache: maven
-      # Set previous Git tag
+
       - name: Set previous Git tag for GitHub Release
         id: previous_tag
         # language=bash
@@ -40,7 +40,7 @@ jobs:
           PREVIOUS_TAG=$(git describe --tags --abbrev=0)
           echo "PREVIOUS_TAG: $PREVIOUS_TAG"
           echo "tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
-      # Post JARs to Maven Central
+
       - name: Release to Maven Central
         env:
           SONAR_USERNAME: ${{ secrets.SONAR_USERNAME }}
@@ -55,17 +55,17 @@ jobs:
           mvn -B --file pom.xml release:prepare
           mvn -B --file pom.xml release:perform
           git push origin main --tags
-      # Upload GitHub pages
+
       - name: Upload Pages Artifact
         # https://github.com/actions/upload-pages-artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./lib/target/site
-      # Deploy GitHub pages
+
       - name: Deploy to GitHub Pages
         id: deployment
         # https://github.com/actions/deploy-pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
         # Set the new tag
       - name: Set the Current Git tag for GitHub Release
         id: current_tag
@@ -74,7 +74,7 @@ jobs:
           CURRENT_TAG=$(git describe --tags --abbrev=0)
           echo "CURRENT_TAG: $CURRENT_TAG"
           echo "tag=$CURRENT_TAG" >> $GITHUB_OUTPUT
-      # Build Github Changelog
+
       - name: Build Github Changelog
         id: github_release
         # https://github.com/mikepenz/release-changelog-builder-action
@@ -107,10 +107,10 @@ jobs:
             }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Create GitHub Release
+
       - name: Create GitHub Release
         # https://github.com/softprops/action-gh-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.current_tag.outputs.tag }}
           body: ${{steps.github_release.outputs.changelog}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: '25'
+          java-version: 25
           distribution: 'zulu'
           cache: maven
 


### PR DESCRIPTION
- Bumped `actions/checkout` to v6 across `release.yml` and `test.yml`
- Updated `actions/setup-java` to v5 in both workflows for Java setup
- Upgraded `actions/upload-pages-artifact` and `actions/deploy-pages` to v5 in `release.yml`
- Migrated `softprops/action-gh-release` to v3 for GitHub Release creation