### PR TITLE
feat: enforce Java 17 & Maven 3.8+ compatibility, add backward compat…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,13 @@ fail_fast: false
 repos:
   - repo: local
     hooks:
+      - id: mvn-compile-java-17-ensure4j
+        name: Maven Backward Compatibility Check
+        entry: mise mvn:compile:17
+        language: system
+        files: ^lib/src
+        require_serial: true
+        pass_filenames: false
       - id: mvn-test-ensure4j
         name: Maven Test ensure4j
         entry: mise mvn:test

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -128,6 +128,32 @@
         <version>3.15.0</version>
       </plugin>
       <plugin>
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-enforcer-plugin -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.8.0</version>
+                  <message>Your Maven version is too old. Ensure4j requires Maven 3.8.0 or higher!</message>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>17</version>
+                  <message>Your Java version is too old. Ensure4j requires Java 17 or higher!</message>
+                </requireJavaVersion>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-gpg-plugin -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>

--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,12 @@ _.python.venv = ".venv"
 
 [tasks."mvn:test"]
 dir = "./lib"
-run = "mvn test"
+run = "mvn clean test"
+
+[tasks."mvn:compile:17"]
+description = "Compile with Java 17 for backwards compatibility check"
+dir = "./lib"
+run = "mvn clean test -Dmaven.compiler.release=17"
 
 [tasks.mvn-format]
 description = "Sort pom.xml and format java code"


### PR DESCRIPTION

- Updated `mise.toml` with new task for Java 17 compilation (`mvn:compile:17`)
- Added Maven Enforcer Plugin to `pom.xml` to enforce minimum Java 17 and Maven 3.8+ versions
- Enhanced `.pre-commit-config.yaml` to include backward compatibility check for Java 17