### PR TITLE
feat: add EnsureDateTimeOps utility with support for future and past/…

### DIFF
--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureDateTimeOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureDateTimeOps.java
@@ -1,0 +1,116 @@
+package io.github.mangila.ensure4j.ops;
+
+import static io.github.mangila.ensure4j.internal.EnsureUtils.getSupplierOrThrow;
+import static io.github.mangila.ensure4j.internal.EnsureUtils.isNull;
+
+import io.github.mangila.ensure4j.EnsureException;
+import java.time.Instant;
+import java.util.function.Supplier;
+
+/**
+ * Provides utility methods for validating and operating on java date time API This enum implements
+ * singleton behavior, ensuring a single instance is used throughout.
+ */
+public enum EnsureDateTimeOps {
+
+  /**
+   * Access point for the {@code EnsureDateTimeOps} singleton. Use this instance to perform date
+   * time operations.
+   */
+  INSTANCE;
+
+  /**
+   * Ensures that the provided instant is in the future.
+   *
+   * @param instant the instant to check
+   * @return the provided instant if it is in the future
+   * @throws EnsureException if the instant is not in the future, with the message {@code "instant
+   *     must be in the future"}
+   * @see #isFuture(Instant, String)
+   * @see #isFuture(Instant, Supplier)
+   */
+  public Instant isFuture(Instant instant) throws EnsureException {
+    return isFuture(instant, "instant must be in the future");
+  }
+
+  /**
+   * Ensures that the provided instant is in the future.
+   *
+   * @param instant the instant to check
+   * @param exceptionMessage the message to include in the exception if validation fails
+   * @return the provided instant if it is in the future
+   * @throws EnsureException if the instant is not in the future, with the provided message
+   * @see #isFuture(Instant)
+   * @see #isFuture(Instant, Supplier)
+   */
+  public Instant isFuture(Instant instant, String exceptionMessage) throws EnsureException {
+    return isFuture(instant, () -> EnsureException.of(exceptionMessage));
+  }
+
+  /**
+   * Ensures that the provided instant is in the future.
+   *
+   * @param instant the instant to check
+   * @param exceptionSupplier the supplier that provides the exception to be thrown if validation
+   *     fails
+   * @return the provided instant if it is in the future
+   * @throws RuntimeException if the instant is not in the future; the thrown exception is provided
+   *     by {@code exceptionSupplier}
+   * @see #isFuture(Instant)
+   * @see #isFuture(Instant, String)
+   */
+  public Instant isFuture(Instant instant, Supplier<? extends RuntimeException> exceptionSupplier) {
+    if (isNull(instant) || !instant.isAfter(Instant.now())) {
+      throw getSupplierOrThrow(exceptionSupplier);
+    }
+    return instant;
+  }
+
+  /**
+   * Ensures that the provided instant is in the past or present.
+   *
+   * @param instant the instant to check
+   * @return the provided instant if it is in the past or present
+   * @throws EnsureException if the instant is not in the past or present, with the message {@code
+   *     "instant must be in the past or present"}
+   * @see #isPastOrPresent(Instant, String)
+   * @see #isPastOrPresent(Instant, Supplier)
+   */
+  public Instant isPastOrPresent(Instant instant) throws EnsureException {
+    return isPastOrPresent(instant, "instant must be in the past or present");
+  }
+
+  /**
+   * Ensures that the provided instant is in the past or present.
+   *
+   * @param instant the instant to check
+   * @param exceptionMessage the message to include in the exception if validation fails
+   * @return the provided instant if it is in the past or present
+   * @throws EnsureException if the instant is not in the past or present, with the provided message
+   * @see #isPastOrPresent(Instant)
+   * @see #isPastOrPresent(Instant, Supplier)
+   */
+  public Instant isPastOrPresent(Instant instant, String exceptionMessage) throws EnsureException {
+    return isPastOrPresent(instant, () -> EnsureException.of(exceptionMessage));
+  }
+
+  /**
+   * Ensures that the provided instant is in the past or present.
+   *
+   * @param instant the instant to check
+   * @param exceptionSupplier the supplier that provides the exception to be thrown if validation
+   *     fails
+   * @return the provided instant if it is in the past or present
+   * @throws RuntimeException if the instant is not in the past or present; the thrown exception is
+   *     provided by {@code exceptionSupplier}
+   * @see #isPastOrPresent(Instant)
+   * @see #isPastOrPresent(Instant, String)
+   */
+  public Instant isPastOrPresent(
+      Instant instant, Supplier<? extends RuntimeException> exceptionSupplier) {
+    if (isNull(instant) || instant.isAfter(Instant.now())) {
+      throw getSupplierOrThrow(exceptionSupplier);
+    }
+    return instant;
+  }
+}

--- a/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureDateTimeOpsTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureDateTimeOpsTest.java
@@ -1,0 +1,78 @@
+package io.github.mangila.ensure4j.ops;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.mangila.ensure4j.EnsureException;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class EnsureDateTimeOpsTest implements EnsureOpsTest<EnsureDateTimeOps> {
+
+  @Override
+  public Class<EnsureDateTimeOps> clazz() {
+    return EnsureDateTimeOps.class;
+  }
+
+  @Override
+  public EnsureDateTimeOps instance() {
+    return EnsureDateTimeOps.INSTANCE;
+  }
+
+  @Override
+  public long expectedPublicMethodCount() {
+    return 8;
+  }
+
+  @Test
+  void isFutureSuccess() {
+    Instant future = Instant.now().plusSeconds(3600);
+    assertThat(instance().isFuture(future)).isEqualTo(future);
+    assertThat(instance().isFuture(future, "message")).isEqualTo(future);
+    assertThat(instance().isFuture(future, () -> new RuntimeException("custom"))).isEqualTo(future);
+  }
+
+  @Test
+  void isFutureThrow() {
+    Instant past = Instant.now().minusSeconds(3600);
+    assertThatThrownBy(() -> instance().isFuture(past))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("instant must be in the future");
+    assertThatThrownBy(() -> instance().isFuture(Instant.now()))
+        .isInstanceOf(EnsureException.class);
+    assertThatThrownBy(() -> instance().isFuture(null)).isInstanceOf(EnsureException.class);
+    assertThatThrownBy(() -> instance().isFuture(past, "message"))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("message");
+    assertThatThrownBy(() -> instance().isFuture(past, () -> new RuntimeException("custom")))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("custom");
+  }
+
+  @Test
+  void isPastOrPresentSuccess() {
+    Instant past = Instant.now().minusSeconds(3600);
+    Instant now = Instant.now();
+    assertThat(instance().isPastOrPresent(past)).isEqualTo(past);
+    assertThat(instance().isPastOrPresent(now)).isEqualTo(now);
+    assertThat(instance().isPastOrPresent(past, "message")).isEqualTo(past);
+    assertThat(instance().isPastOrPresent(past, () -> new RuntimeException("custom")))
+        .isEqualTo(past);
+  }
+
+  @Test
+  void isPastOrPresentThrow() {
+    Instant future = Instant.now().plusSeconds(3600);
+    assertThatThrownBy(() -> instance().isPastOrPresent(future))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("instant must be in the past or present");
+    assertThatThrownBy(() -> instance().isPastOrPresent(null)).isInstanceOf(EnsureException.class);
+    assertThatThrownBy(() -> instance().isPastOrPresent(future, "message"))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("message");
+    assertThatThrownBy(
+            () -> instance().isPastOrPresent(future, () -> new RuntimeException("custom")))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("custom");
+  }
+}

--- a/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureOpsArchitectureTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureOpsArchitectureTest.java
@@ -9,7 +9,7 @@ class EnsureOpsArchitectureTest {
 
   @Test
   void shouldCountOpsEnums() {
-    final int expectedOpsCount = 8;
+    final int expectedOpsCount = 9;
     final var ensureOpsClasses = ArchTestUtils.ENSURE_OPS_CLASSES.stream().toList();
     assertThat(ensureOpsClasses)
         .as(


### PR DESCRIPTION
…present validation

- Introduced `EnsureDateTimeOps` as an enum for date-time operation validations
- Added methods for ensuring an `Instant` is in the future or in the past/present, with customizable exception messages or suppliers
- Updated architecture test to account for the new `EnsureDateTimeOps` class
- Added corresponding unit tests for `EnsureDateTimeOps` validating correct behavior and exceptions