### PR TITLE
feat: add regex-based string validation utility to EnsureStringOps

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -49,6 +49,13 @@
       <artifactId>jspecify</artifactId>
       <version>1.0.0</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>26.1.0</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- https://mvnrepository.com/artifact/com.tngtech.archunit/archunit -->
     <dependency>
       <groupId>com.tngtech.archunit</groupId>

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureStringOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureStringOps.java
@@ -4,6 +4,7 @@ import static io.github.mangila.ensure4j.internal.EnsureUtils.*;
 
 import io.github.mangila.ensure4j.EnsureException;
 import java.util.function.Supplier;
+import org.intellij.lang.annotations.RegExp;
 
 /**
  * Provides utility methods for validating and operating on strings. This enum implements singleton
@@ -311,6 +312,63 @@ public enum EnsureStringOps {
       throw EnsureException.of("suffix must not be null");
     }
     if (isNull(string) || !string.endsWith(suffix)) {
+      throw getSupplierOrThrow(exceptionSupplier);
+    }
+    return string;
+  }
+
+  /**
+   * Ensures that the provided string matches the specified regular expression.
+   *
+   * @param regex the regular expression to match against
+   * @param string the string to check
+   * @return the provided string if it matches the regular expression
+   * @throws EnsureException if the string does not match the regular expression, with the message
+   *     {@code "string must match regex '%s'"}
+   * @see #matches(String, String, String)
+   * @see #matches(String, String, Supplier)
+   */
+  public String matches(@RegExp String regex, String string) throws EnsureException {
+    return matches(regex, string, "string must match regex '%s'".formatted(regex));
+  }
+
+  /**
+   * Ensures that the provided string matches the specified regular expression.
+   *
+   * @param regex the regular expression to match against
+   * @param string the string to check
+   * @param exceptionMessage the message to include in the exception if validation fails
+   * @return the provided string if it matches the regular expression
+   * @throws EnsureException if the string does not match the regular expression, with the provided
+   *     message
+   * @see #matches(String, String)
+   * @see #matches(String, String, Supplier)
+   */
+  public String matches(@RegExp String regex, String string, String exceptionMessage)
+      throws EnsureException {
+    return matches(regex, string, () -> EnsureException.of(exceptionMessage));
+  }
+
+  /**
+   * Ensures that the provided string matches the specified regular expression.
+   *
+   * @param regex the regular expression to match against
+   * @param string the string to check
+   * @param exceptionSupplier the supplier that provides the exception to be thrown if validation
+   *     fails
+   * @return the provided string if it matches the regular expression
+   * @throws RuntimeException if the string does not match the regular expression; the thrown
+   *     exception is provided by {@code exceptionSupplier}
+   * @see #matches(String, String)
+   * @see #matches(String, String, String)
+   */
+  public String matches(
+      @RegExp String regex, String string, Supplier<? extends RuntimeException> exceptionSupplier)
+      throws RuntimeException {
+    if (isNull(regex)) {
+      throw EnsureException.of("regex must not be null");
+    }
+    if (isNull(string) || !string.matches(regex)) {
       throw getSupplierOrThrow(exceptionSupplier);
     }
     return string;

--- a/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureStringOpsTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureStringOpsTest.java
@@ -20,7 +20,7 @@ class EnsureStringOpsTest implements EnsureOpsTest<EnsureStringOps> {
 
   @Override
   public long expectedPublicMethodCount() {
-    return 19;
+    return 22;
   }
 
   @Test
@@ -220,6 +220,40 @@ class EnsureStringOpsTest implements EnsureOpsTest<EnsureStringOps> {
                 instance()
                     .endsWith(
                         "hello", "hello world", () -> new RuntimeException("custom exception")))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("custom exception");
+  }
+
+  @Test
+  void matchesSuccess() {
+    String value = "123";
+    assertThat(instance().matches("\\d+", value)).isEqualTo(value);
+  }
+
+  @Test
+  void matchesFailure() {
+    assertThatThrownBy(() -> instance().matches("\\d+", "abc"))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("string must match regex '\\d+'");
+    assertThatThrownBy(() -> instance().matches("\\d+", null))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("string must match regex '\\d+'");
+    assertThatThrownBy(() -> instance().matches(null, "123"))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("regex must not be null");
+  }
+
+  @Test
+  void matchesCustomMessage() {
+    assertThatThrownBy(() -> instance().matches("\\d+", "abc", "custom message"))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("custom message");
+  }
+
+  @Test
+  void matchesCustomSupplier() {
+    assertThatThrownBy(
+            () -> instance().matches("\\d+", "abc", () -> new RuntimeException("custom exception")))
         .isInstanceOf(RuntimeException.class)
         .hasMessage("custom exception");
   }


### PR DESCRIPTION
- Introduced `matches` methods in `EnsureStringOps` for regex validation with customizable exception messages and suppliers
- Added `@RegExp` annotation for regex parameters to improve static analysis
- Updated `EnsureStringOpsTest` to include test cases for regex validation
- Included `org.jetbrains:annotations` dependency in the Maven POM to support `@RegExp` annotation