### PR TITLE
chore(release): add prepareVerifyArgs to Maven release plugin configu…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
           export GPG_TTY=$(tty)
           git config --global user.name "GitHub Actions"
           git config --global user.email "olsson.erik1993@gmail.com"
-          mvn -B --file pom.xml release:prepare
-          mvn -B --file pom.xml release:perform
+          mvn -B --no-transfer-progress --file pom.xml release:prepare
+          mvn -B --no-transfer-progress --file pom.xml release:perform
           git push origin main --tags
 
       - name: Upload Pages Artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
           cache: maven
 
       - name: Run tests (lib)
-        run: mvn -B test --file lib/pom.xml
+        run: mvn -B --no-transfer-progress test --file lib/pom.xml

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -198,6 +198,7 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>3.3.1</version>
         <configuration>
+          <prepareVerifyArgs>-B -DskipTests</prepareVerifyArgs>
           <preparationGoals>package site</preparationGoals>
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -198,7 +198,7 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>3.3.1</version>
         <configuration>
-          <prepareVerifyArgs>-B -DskipTests</prepareVerifyArgs>
+          <prepareVerifyArgs>-B --no-transfer-progress -DskipTests</prepareVerifyArgs>
           <preparationGoals>package site</preparationGoals>
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>


### PR DESCRIPTION
…ration

- Configured `prepareVerifyArgs` with `-B -DskipTests` to streamline non-interactive builds
- Maintains preparation goals and local checkout settings