### PR TITLE
chore(refactor): replace custom `isNull` utility and deprecate unused…

### DIFF
--- a/lib/src/main/java/io/github/mangila/ensure4j/Ensure.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/Ensure.java
@@ -104,7 +104,10 @@ public final class Ensure {
    * @return the non-null {@code object}, or the value provided by the {@code fallbackSupplier}
    * @throws EnsureException if the {@code fallbackSupplier} is null or produces a null value
    * @see EnsureNullOps#notNullOrElseGet(Object, Supplier)
+   * @deprecated since 3.0.4, use {@link java.util.Objects#requireNonNullElseGet(Object, Supplier)}
+   *     instead
    */
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public static <T> T notNullOrElseGet(T object, Supplier<T> fallbackSupplier)
       throws EnsureException {
     return NULL_OPS.notNullOrElseGet(object, fallbackSupplier);
@@ -119,8 +122,11 @@ public final class Ensure {
    * @param defaultObject the default object to return if {@code object} is null
    * @return {@code object} if it is not null, otherwise {@code defaultObject}
    * @see EnsureNullOps#notNullOrElse(Object, Object)
+   * @deprecated since 3.0.4, use {@link java.util.Objects#requireNonNullElse(Object, Object)}
+   *     instead
    */
   @Contract("null, _ -> param2; !null, _ -> param1")
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public static <T> T notNullOrElse(T object, T defaultObject) {
     return NULL_OPS.notNullOrElse(object, defaultObject);
   }

--- a/lib/src/main/java/io/github/mangila/ensure4j/internal/EnsureUtils.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/internal/EnsureUtils.java
@@ -23,16 +23,6 @@ public final class EnsureUtils {
   }
 
   /**
-   * Checks whether the given object is null.
-   *
-   * @param object the object to check for nullity
-   * @return true if the given object is null, false otherwise
-   */
-  public static boolean isNull(Object object) {
-    return object == null;
-  }
-
-  /**
    * Retrieves the value provided by the given {@link Supplier}. If the supplier is null or the
    * supplied value is null, an {@link EnsureException} is thrown.
    *

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureArrayOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureArrayOps.java
@@ -1,7 +1,7 @@
 package io.github.mangila.ensure4j.ops;
 
 import static io.github.mangila.ensure4j.internal.EnsureUtils.getSupplierOrThrow;
-import static io.github.mangila.ensure4j.internal.EnsureUtils.isNull;
+import static java.util.Objects.isNull;
 
 import io.github.mangila.ensure4j.EnsureException;
 import java.util.function.Supplier;

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureCollectionOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureCollectionOps.java
@@ -1,7 +1,7 @@
 package io.github.mangila.ensure4j.ops;
 
 import static io.github.mangila.ensure4j.internal.EnsureUtils.getSupplierOrThrow;
-import static io.github.mangila.ensure4j.internal.EnsureUtils.isNull;
+import static java.util.Objects.isNull;
 
 import io.github.mangila.ensure4j.EnsureException;
 import java.util.Collection;

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureDateTimeOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureDateTimeOps.java
@@ -1,7 +1,7 @@
 package io.github.mangila.ensure4j.ops;
 
 import static io.github.mangila.ensure4j.internal.EnsureUtils.getSupplierOrThrow;
-import static io.github.mangila.ensure4j.internal.EnsureUtils.isNull;
+import static java.util.Objects.isNull;
 
 import io.github.mangila.ensure4j.EnsureException;
 import java.time.Instant;

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureMapOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureMapOps.java
@@ -1,7 +1,7 @@
 package io.github.mangila.ensure4j.ops;
 
 import static io.github.mangila.ensure4j.internal.EnsureUtils.getSupplierOrThrow;
-import static io.github.mangila.ensure4j.internal.EnsureUtils.isNull;
+import static java.util.Objects.isNull;
 
 import io.github.mangila.ensure4j.EnsureException;
 import java.util.Map;

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureNullOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureNullOps.java
@@ -1,7 +1,7 @@
 package io.github.mangila.ensure4j.ops;
 
 import static io.github.mangila.ensure4j.internal.EnsureUtils.getSupplierOrThrow;
-import static io.github.mangila.ensure4j.internal.EnsureUtils.isNull;
+import static java.util.Objects.isNull;
 
 import io.github.mangila.ensure4j.EnsureException;
 import java.util.function.Supplier;
@@ -30,6 +30,7 @@ public enum EnsureNullOps {
    * @see #notNullOrElseGet(Object, Supplier)
    */
   @Contract("null, _ -> param2; !null, _ -> param1")
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public <T> T notNullOrElse(T object, T defaultObject) {
     if (isNull(object)) {
       return defaultObject;
@@ -48,6 +49,7 @@ public enum EnsureNullOps {
    * @throws EnsureException if the {@code fallbackSupplier} is null or produces a null value
    * @see #notNullOrElse(Object, Object)
    */
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public <T> T notNullOrElseGet(T object, Supplier<T> fallbackSupplier) throws EnsureException {
     if (isNull(object)) {
       return getSupplierOrThrow(fallbackSupplier);

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureObjectOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureObjectOps.java
@@ -2,9 +2,10 @@ package io.github.mangila.ensure4j.ops;
 
 import static io.github.mangila.ensure4j.Ensure.notNull;
 import static io.github.mangila.ensure4j.internal.EnsureUtils.getSupplierOrThrow;
-import static io.github.mangila.ensure4j.internal.EnsureUtils.isNull;
+import static java.util.Objects.isNull;
 
 import io.github.mangila.ensure4j.EnsureException;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.jetbrains.annotations.Contract;
 
@@ -94,9 +95,11 @@ public enum EnsureObjectOps {
    *     be equal"}
    * @see #isEquals(Enum, Enum, String)
    * @see #isEquals(Enum, Enum, Supplier)
+   * @deprecated use {@link #isEquals(Object, Object)} instead
    */
   @Contract(
       "null, !null -> fail; !null, null -> fail; null, null -> param1; !null, !null -> param1")
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public <T extends Enum<T>> T isEquals(T enum1, T enum2) throws EnsureException {
     return isEquals(enum1, enum2, "enums must be equal");
   }
@@ -112,9 +115,11 @@ public enum EnsureObjectOps {
    * @throws EnsureException if the enum values are not equal, with the provided message
    * @see #isEquals(Enum, Enum)
    * @see #isEquals(Enum, Enum, Supplier)
+   * @deprecated use {@link #isEquals(Object, Object, String)} instead
    */
   @Contract(
       "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public <T extends Enum<T>> T isEquals(T enum1, T enum2, String exceptionMessage)
       throws EnsureException {
     return isEquals(enum1, enum2, () -> EnsureException.of(exceptionMessage));
@@ -133,9 +138,11 @@ public enum EnsureObjectOps {
    *     {@code exceptionSupplier}
    * @see #isEquals(Enum, Enum)
    * @see #isEquals(Enum, Enum, String)
+   * @deprecated use {@link #isEquals(Object, Object, Supplier)} instead
    */
   @Contract(
       "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public <T extends Enum<T>> T isEquals(
       T enum1, T enum2, Supplier<? extends RuntimeException> exceptionSupplier)
       throws RuntimeException {
@@ -201,15 +208,11 @@ public enum EnsureObjectOps {
   public <T> T isEquals(
       T object, Object otherObject, Supplier<? extends RuntimeException> exceptionSupplier)
       throws RuntimeException {
-    if (object == otherObject) {
+    final boolean eq = Objects.equals(object, otherObject);
+    if (eq) {
       return object;
-    }
-    if (isNull(object)) {
+    } else {
       throw getSupplierOrThrow(exceptionSupplier);
     }
-    if (object.equals(otherObject)) {
-      return object;
-    }
-    throw getSupplierOrThrow(exceptionSupplier);
   }
 }

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureStringOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureStringOps.java
@@ -1,6 +1,8 @@
 package io.github.mangila.ensure4j.ops;
 
-import static io.github.mangila.ensure4j.internal.EnsureUtils.*;
+import static io.github.mangila.ensure4j.internal.EnsureUtils.getSupplierOrThrow;
+import static io.github.mangila.ensure4j.internal.EnsureUtils.isBlank;
+import static java.util.Objects.isNull;
 
 import io.github.mangila.ensure4j.EnsureException;
 import java.util.function.Supplier;

--- a/lib/src/test/java/io/github/mangila/ensure4j/EnsureTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/EnsureTest.java
@@ -86,6 +86,7 @@ class EnsureTest {
               Ensure.notNull("str", () -> new RuntimeException("custom"));
             })
         .doesNotThrowAnyException();
+    // TODO: remove
     assertThatCode(() -> Ensure.notNullOrElse("str", "fallback")).doesNotThrowAnyException();
     assertThatCode(() -> Ensure.notNullOrElseGet("str", () -> "fallback"))
         .doesNotThrowAnyException();

--- a/lib/src/test/java/io/github/mangila/ensure4j/internal/EnsureUtilsTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/internal/EnsureUtilsTest.java
@@ -30,12 +30,6 @@ class EnsureUtilsTest {
   }
 
   @Test
-  void isNull() {
-    Object o = null;
-    assertTrue(EnsureUtils.isNull(o));
-  }
-
-  @Test
   void getSupplierOrThrow() {
     assertThatThrownBy(() -> EnsureUtils.getSupplierOrThrow(null))
         .isInstanceOf(EnsureException.class)

--- a/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureNullOpsTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureNullOpsTest.java
@@ -47,6 +47,7 @@ class EnsureNullOpsTest implements EnsureOpsTest<EnsureNullOps> {
         .hasMessage("message");
   }
 
+  // TODO: remove
   @Test
   void notNullOrElse() {
     var str = "test";
@@ -55,6 +56,7 @@ class EnsureNullOpsTest implements EnsureOpsTest<EnsureNullOps> {
     assertThat(instance().notNullOrElse(null, fallBack)).isEqualTo(fallBack);
   }
 
+  // TODO: remove
   @Test
   void notNullOrElseGet() {
     var str = "test";

--- a/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureObjectOpsTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureObjectOpsTest.java
@@ -78,7 +78,6 @@ class EnsureObjectOpsTest implements EnsureOpsTest<EnsureObjectOps> {
 
     enum TestEnum {
       A,
-      B
     }
 
     TestEnum val1 = TestEnum.A;


### PR DESCRIPTION
… Ensure APIs

- Removed `EnsureUtils.isNull` in favor of `java.util.Objects.isNull` for standardization across operations
- Marked `notNullOrElse` and `notNullOrElseGet` as deprecated in `EnsureNullOps` and `Ensure`
- Streamlined `isEquals` implementations to improve readability and use standard `Objects.equals` method
- Cleaned up redundant enum value and added TODO markers for unused test cases