### PR TITLE
chore(docs): mark deprecated methods in EnsureStringOps and EnsureNul…

### DIFF
--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureNullOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureNullOps.java
@@ -28,6 +28,7 @@ public enum EnsureNullOps {
    * @param defaultObject the default object to return if {@code object} is null
    * @return {@code object} if it is not null, otherwise {@code defaultObject}
    * @see #notNullOrElseGet(Object, Supplier)
+   * @deprecated Use {@link java.util.Objects#requireNonNullElse(Object, Object)} instead.
    */
   @Contract("null, _ -> param2; !null, _ -> param1")
   @Deprecated(since = "3.0.4", forRemoval = true)
@@ -48,6 +49,7 @@ public enum EnsureNullOps {
    * @return the non-null {@code object}, or the value provided by the {@code fallbackSupplier}
    * @throws EnsureException if the {@code fallbackSupplier} is null or produces a null value
    * @see #notNullOrElse(Object, Object)
+   * @deprecated Use {@link java.util.Objects#requireNonNullElseGet(Object, Supplier)} instead.
    */
   @Deprecated(since = "3.0.4", forRemoval = true)
   public <T> T notNullOrElseGet(T object, Supplier<T> fallbackSupplier) throws EnsureException {

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureStringOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureStringOps.java
@@ -31,8 +31,10 @@ public enum EnsureStringOps {
    * @return the non-blank {@code string}, or the value provided by the {@code fallbackSupplier}
    * @throws EnsureException if the {@code fallbackSupplier} is null or produces a null value
    * @see #notBlankOrElse(String, String)
+   * @deprecated
    */
   @Contract("null, _ -> fail; !null, _ -> param1")
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public String notBlankOrElseGet(String string, Supplier<String> fallbackSupplier) {
     if (isNull(string) || isBlank(string)) {
       return getSupplierOrThrow(fallbackSupplier);
@@ -48,8 +50,10 @@ public enum EnsureStringOps {
    * @param fallbackValue the default value to return if {@code string} is null or blank
    * @return {@code string} if it is not null or blank, otherwise {@code fallbackValue}
    * @see #notBlankOrElseGet(String, Supplier)
+   * @deprecated
    */
   @Contract("null, _ -> param2; !null, _ -> param1")
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public String notBlankOrElse(String string, String fallbackValue) {
     if (isNull(string) || isBlank(string)) {
       return fallbackValue;


### PR DESCRIPTION
…lOps

- Annotated `notBlankOrElse`, `notBlankOrElseGet`, `notNullOrElse`, and `notNullOrElseGet` as deprecated, with `since` and `forRemoval` details.
- Added references to preferred alternatives from `java.util.Objects`.