### PR TITLE
chore(build): update Maven plugins, GitHub Actions, and linters config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         id: deployment
         # https://github.com/actions/deploy-pages
         uses: actions/deploy-pages@v5
-        # Set the new tag
+
       - name: Set the Current Git tag for GitHub Release
         id: current_tag
         # language=bash

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -9,8 +9,9 @@
 APPLY_FIXES: none
 PRINT_ALL_FILES: true
 
-LOG_LEVEL: DEBUG
+CLEAR_REPORT_FOLDER: true
 
+LOG_LEVEL: DEBUG
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true
 ENABLE_LINTERS:
   # https://megalinter.io/latest/descriptors/java_checkstyle/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
         files: ^lib/src
         require_serial: true
         pass_filenames: false
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
     hooks:

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -199,11 +199,17 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>3.3.1</version>
         <configuration>
-          <prepareVerifyArgs>-B --no-transfer-progress -DskipTests</prepareVerifyArgs>
+          <prepareVerifyArgs>-B --no-transfer-progress</prepareVerifyArgs>
           <preparationGoals>package site</preparationGoals>
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>
         </configuration>
+      </plugin>
+      <plugin>
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-site-plugin -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.21.0</version>
       </plugin>
       <plugin>
         <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-source-plugin -->
@@ -266,13 +272,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.12.0</version>
-        <reportSets>
-          <reportSet>
-            <reports>
-              <report>javadoc</report>
-            </reports>
-          </reportSet>
-        </reportSets>
       </plugin>
       <plugin>
         <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-jxr-plugin -->


### PR DESCRIPTION
- Upgraded `maven-site-plugin` to v3.21.0 in `lib/pom.xml`
- Removed unused `javadoc` report set from `maven-javadoc-plugin` configuration
- Adjusted pre-commit hooks and enhanced `.pre-commit-config.yaml`
- Improved `.mega-linter.yml` by enabling `CLEAR_REPORT_FOLDER` option
- Refined GitHub Actions `release.yml` for streamlined workflows