### PR TITLE
chore(ci): add workflow to label PRs with release version

### DIFF
--- a/.github/workflows/add-pr-version-label.yml
+++ b/.github/workflows/add-pr-version-label.yml
@@ -1,0 +1,20 @@
+name: Add Release Label to PR
+
+on:
+  pull_request:
+    types: [ opened, reopened ]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  id-token: write
+
+jobs:
+  add-release-label:
+    runs-on: ubuntu-latest
+    env:
+      LABEL: "3.0.4"
+    steps:
+      - name: Add hardcoded release label
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "${{ env.LABEL }}"


### PR DESCRIPTION
- Introduced `add-pr-version-label.yml` workflow to add a hardcoded release label (`3.0.4`) to pull requests opened or reopened against the `main` branch using GitHub CLI.