### PR TITLE
docs(README:GUIDELINES): improve task syntax, guidelines, and pre-com…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
           cache: maven
 
       - name: Set previous Git tag for GitHub Release
-        id: previous_tag
         # language=bash
         run: |
           TAG=$(git describe --tags --abbrev=0)
@@ -71,7 +70,6 @@ jobs:
         uses: actions/deploy-pages@v5
 
       - name: Set the Current Git tag for GitHub Release
-        id: current_tag
         # language=bash
         run: |
           TAG=$(git describe --tags --abbrev=0)

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -17,14 +17,21 @@ You are a Java developer and an QA Engineer, and you want to contribute to the p
 
 ## Coding Guidelines and Javadocs
 
-- Make sure formatting is correct by runnig `mvn -f lib/pom.xml com.spotify.fmt:fmt-maven-plugin:format`
+Make sure the formatting is correct by running the mise task:
+```bash
+mise run mvn:format
+```
+
 - Make sure the methods are implemented for the overloaded methods following the Step-down Rule (or the Newspaper
   Metaphor).
+- Create methods with descriptive name
+- Use contracts for methods with the annotation `@org.jetbrains.annotations.Contract;`
+- Use Javadocs for all public methods
 
-Create methods with descriptive names and javadocs in the following format:
+Add Javadocs in the following format:
 
 ```java
-/**
+ /**
  * Ensures that the provided array is not null or empty.
  *
  * @param <T> the component type of the array
@@ -35,8 +42,9 @@ Create methods with descriptive names and javadocs in the following format:
  * @see #notEmpty(Object[], String)
  * @see #notEmpty(Object[], Supplier)
  */
+@Contract("null -> fail; !null -> param1")
 public <T> T[] notEmpty(T[] array) {
-    return notEmpty(array, "array must not be empty");
+  return notEmpty(array, "array must not be empty");
 }
 
 /**
@@ -50,8 +58,9 @@ public <T> T[] notEmpty(T[] array) {
  * @see #notEmpty(Object[])
  * @see #notEmpty(Object[], Supplier)
  */
+@Contract("null, _ -> fail; !null, _ -> param1")
 public <T> T[] notEmpty(T[] array, String exceptionMessage) {
-    return notEmpty(array, () -> EnsureException.of(exceptionMessage));
+  return notEmpty(array, () -> EnsureException.of(exceptionMessage));
 }
 
 /**
@@ -67,11 +76,12 @@ public <T> T[] notEmpty(T[] array, String exceptionMessage) {
  * @see #notEmpty(Object[])
  * @see #notEmpty(Object[], String)
  */
+@Contract("null, _ -> fail; !null, _ -> param1")
 public <T> T[] notEmpty(T[] array, Supplier<? extends RuntimeException> exceptionSupplier) {
-    if (isNull(array) || array.length == 0) {
-        throw getSupplierOrThrow(exceptionSupplier);
-    }
-    return array;
+  if (isNull(array) || array.length == 0) {
+    throw getSupplierOrThrow(exceptionSupplier);
+  }
+  return array;
 }
 ```
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: mvn-validate-ensure4j
         name: Maven Validate ensure4j
-        entry: mise mvn:validate
+        entry: mise run mvn:validate
         language: system
         files: ^lib/src
         require_serial: true

--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ public void placeOrder(Order order) {
 
 Predefined exception messages are builtin in the library if you don't want to provide a custom one.
 
-**NOTE: Use well-defined exception messages. They should be self-explanatory and provide enough context to help
-understand the problem. The default ones might not be enough for your use case.**
+> [!WARNING]
+> Use well-defined exception messages. They should be self-explanatory and provide enough context to help
+understand the problem. The default ones might not be enough for your use case.
 
 ```java
 import io.github.mangila.ensure4j.Ensure;

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ _.python.venv = ".venv"
 dir = "./lib"
 run = "mvn clean validate"
 
-[tasks.mvn-format]
+[tasks."mvn:format"]
 description = "Sort pom.xml and format java code"
 dir = "./lib"
 run = [


### PR DESCRIPTION
…mit integration

- Updated `mise.toml` to use quoted task names (e.g., `"mvn:format"`) for compatibility
- Revised coding guidelines to reference `mise run mvn:format` for formatting consistency
- Enhanced `.pre-commit-config.yaml` to align with updated `mise` task syntax
- Updated README formatting for better readability of warning notes