### PR TITLE
feat(objectops): add `isDeepEquals`

### DIFF
--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureObjectOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureObjectOps.java
@@ -209,4 +209,66 @@ public enum EnsureObjectOps {
       throw getSupplierOrThrow(exceptionSupplier);
     }
   }
+
+  /**
+   * Ensures that the provided objects are deeply equal.
+   *
+   * @param <T> the type of the object
+   * @param object the first object
+   * @param otherObject the second object
+   * @return the first object if they are deeply equal
+   * @throws EnsureException if the objects are not deeply equal, with the message {@code "objects
+   *     must be deeply equal"}
+   * @see #isDeepEquals(Object, Object, String)
+   * @see #isDeepEquals(Object, Object, Supplier)
+   */
+  @Contract(
+      "null, !null -> fail; !null, null -> fail; null, null -> param1; !null, !null -> param1")
+  public <T> T isDeepEquals(T object, Object otherObject) {
+    return isDeepEquals(object, otherObject, "objects must be deeply equal");
+  }
+
+  /**
+   * Ensures that the provided objects are deeply equal.
+   *
+   * @param <T> the type of the object
+   * @param object the first object
+   * @param otherObject the second object
+   * @param exceptionMessage the message to include in the exception if validation fails
+   * @return the first object if they are deeply equal
+   * @throws EnsureException if the objects are not deeply equal, with the provided message
+   * @see #isDeepEquals(Object, Object)
+   * @see #isDeepEquals(Object, Object, Supplier)
+   */
+  @Contract(
+      "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
+  public <T> T isDeepEquals(T object, Object otherObject, String exceptionMessage) {
+    return isDeepEquals(object, otherObject, () -> EnsureException.of(exceptionMessage));
+  }
+
+  /**
+   * Ensures that the provided objects are deeply equal.
+   *
+   * @param <T> the type of the object
+   * @param object the first object
+   * @param otherObject the second object
+   * @param exceptionSupplier the supplier that provides the exception to be thrown if validation
+   *     fails
+   * @return the first object if they are deeply equal
+   * @throws RuntimeException if the objects are not deeply equal; the thrown exception is provided
+   *     by {@code exceptionSupplier}
+   * @see #isDeepEquals(Object, Object)
+   * @see #isDeepEquals(Object, Object, String)
+   */
+  @Contract(
+      "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
+  public <T> T isDeepEquals(
+      T object, Object otherObject, Supplier<? extends RuntimeException> exceptionSupplier) {
+    final boolean eq = Objects.deepEquals(object, otherObject);
+    if (eq) {
+      return object;
+    } else {
+      throw getSupplierOrThrow(exceptionSupplier);
+    }
+  }
 }

--- a/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureObjectOpsTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureObjectOpsTest.java
@@ -20,7 +20,46 @@ class EnsureObjectOpsTest implements EnsureOpsTest<EnsureObjectOps> {
 
   @Override
   public long expectedPublicMethodCount() {
-    return 11;
+    return 14;
+  }
+
+  @Test
+  void isDeepEqualsSuccess() {
+    String[] val1 = {"test"};
+    String[] val2 = {"test"};
+    String[] result = instance().isDeepEquals(val1, val2);
+    assertThat(result).isEqualTo(val1);
+  }
+
+  @Test
+  void isDeepEqualsFailure() {
+    String[] val1 = {"test"};
+    String[] val2 = {"other"};
+    assertThatThrownBy(() -> instance().isDeepEquals(val1, val2))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("objects must be deeply equal");
+  }
+
+  @Test
+  void isDeepEqualsCustomMessage() {
+    String[] val1 = {"test"};
+    String[] val2 = {"other"};
+    assertThatThrownBy(() -> instance().isDeepEquals(val1, val2, "custom message"))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("custom message");
+  }
+
+  @Test
+  void isDeepEqualsCustomException() {
+    String[] val1 = {"test"};
+    String[] val2 = {"other"};
+    assertThatThrownBy(
+            () ->
+                instance()
+                    .isDeepEquals(
+                        val1, val2, () -> new IllegalArgumentException("custom exception")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("custom exception");
   }
 
   @Test


### PR DESCRIPTION
- Introduced `isDeepEquals` methods in `EnsureObjectOps` for deep equality checks with customizable exception messages and exceptions.
- Added comprehensive unit tests: success, failure, custom message, and custom exception scenarios.