### PR TITLE
feat(arrayops): add array equality and deep equality validation methods

### DIFF
--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureArrayOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureArrayOps.java
@@ -4,6 +4,7 @@ import static io.github.mangila.ensure4j.internal.EnsureUtils.getSupplierOrThrow
 import static java.util.Objects.isNull;
 
 import io.github.mangila.ensure4j.EnsureException;
+import java.util.Arrays;
 import java.util.function.Supplier;
 import org.jetbrains.annotations.Contract;
 
@@ -69,5 +70,129 @@ public enum EnsureArrayOps {
       throw getSupplierOrThrow(exceptionSupplier);
     }
     return array;
+  }
+
+  /**
+   * Ensures that the provided arrays are equal.
+   *
+   * @param <T> the component type of the array
+   * @param array the first array
+   * @param otherArray the second array
+   * @return the first array if they are equal
+   * @throws EnsureException if the arrays are not equal, with the message {@code "arrays must be
+   *     equal"}
+   * @see #equalTo(Object[], Object[], String)
+   * @see #equalTo(Object[], Object[], Supplier)
+   */
+  @Contract(
+      "null, !null -> fail; !null, null -> fail; null, null -> param1; !null, !null -> param1")
+  public <T> T[] equalTo(T[] array, T[] otherArray) {
+    return equalTo(array, otherArray, "arrays must be equal");
+  }
+
+  /**
+   * Ensures that the provided arrays are equal.
+   *
+   * @param <T> the component type of the array
+   * @param array the first array
+   * @param otherArray the second array
+   * @param exceptionMessage the message to include in the exception if validation fails
+   * @return the first array if they are equal
+   * @throws EnsureException if the arrays are not equal, with the provided message
+   * @see #equalTo(Object[], Object[])
+   * @see #equalTo(Object[], Object[], Supplier)
+   */
+  @Contract(
+      "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
+  public <T> T[] equalTo(T[] array, T[] otherArray, String exceptionMessage) {
+    return equalTo(array, otherArray, () -> EnsureException.of(exceptionMessage));
+  }
+
+  /**
+   * Ensures that the provided arrays are equal.
+   *
+   * @param <T> the component type of the array
+   * @param array the first array
+   * @param otherArray the second array
+   * @param exceptionSupplier the supplier that provides the exception to be thrown if validation
+   *     fails
+   * @return the first array if they are equal
+   * @throws RuntimeException if the arrays are not equal; the thrown exception is provided by
+   *     {@code exceptionSupplier}
+   * @see #equalTo(Object[], Object[])
+   * @see #equalTo(Object[], Object[], String)
+   */
+  @Contract(
+      "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
+  public <T> T[] equalTo(
+      T[] array, T[] otherArray, Supplier<? extends RuntimeException> exceptionSupplier) {
+    final boolean eq = Arrays.equals(array, otherArray);
+    if (eq) {
+      return array;
+    } else {
+      throw getSupplierOrThrow(exceptionSupplier);
+    }
+  }
+
+  /**
+   * Ensures that the provided arrays are deeply equal.
+   *
+   * @param <T> the component type of the array
+   * @param array the first array
+   * @param otherArray the second array
+   * @return the first array if they are deeply equal
+   * @throws EnsureException if the arrays are not deeply equal, with the message {@code "arrays
+   *     must be deeply equal"}
+   * @see #deepEqualTo(Object[], Object[], String)
+   * @see #deepEqualTo(Object[], Object[], Supplier)
+   */
+  @Contract(
+      "null, !null -> fail; !null, null -> fail; null, null -> param1; !null, !null -> param1")
+  public <T> T[] deepEqualTo(T[] array, T[] otherArray) {
+    return deepEqualTo(array, otherArray, "arrays must be deeply equal");
+  }
+
+  /**
+   * Ensures that the provided arrays are deeply equal.
+   *
+   * @param <T> the component type of the array
+   * @param array the first array
+   * @param otherArray the second array
+   * @param exceptionMessage the message to include in the exception if validation fails
+   * @return the first array if they are deeply equal
+   * @throws EnsureException if the arrays are not deeply equal, with the provided message
+   * @see #deepEqualTo(Object[], Object[])
+   * @see #deepEqualTo(Object[], Object[], Supplier)
+   */
+  @Contract(
+      "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
+  public <T> T[] deepEqualTo(T[] array, T[] otherArray, String exceptionMessage) {
+    return deepEqualTo(array, otherArray, () -> EnsureException.of(exceptionMessage));
+  }
+
+  /**
+   * Ensures that the provided arrays are deeply equal.
+   *
+   * @param <T> the component type of the array
+   * @param array the first array
+   * @param otherArray the second array
+   * @param exceptionSupplier the supplier that provides the exception to be thrown if validation
+   *     fails
+   * @return the first array if they are deeply equal
+   * @throws RuntimeException if the arrays are not deeply equal; the thrown exception is provided
+   *     by {@code exceptionSupplier}
+   * @see #deepEqualTo(Object[], Object[])
+   * @see #deepEqualTo(Object[], Object[], String)
+   */
+  @Contract(
+      "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
+  public <T> T[] deepEqualTo(
+      T[] array, T[] otherArray, Supplier<? extends RuntimeException> exceptionSupplier) {
+    final boolean eq = Arrays.deepEquals(array, otherArray);
+    if (eq) {
+      return array;
+    } else {
+      throw getSupplierOrThrow(exceptionSupplier);
+    }
   }
 }

--- a/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureObjectOps.java
+++ b/lib/src/main/java/io/github/mangila/ensure4j/ops/EnsureObjectOps.java
@@ -219,13 +219,13 @@ public enum EnsureObjectOps {
    * @return the first object if they are deeply equal
    * @throws EnsureException if the objects are not deeply equal, with the message {@code "objects
    *     must be deeply equal"}
-   * @see #isDeepEquals(Object, Object, String)
-   * @see #isDeepEquals(Object, Object, Supplier)
+   * @see #deepEqualTo(Object, Object, String)
+   * @see #deepEqualTo(Object, Object, Supplier)
    */
   @Contract(
       "null, !null -> fail; !null, null -> fail; null, null -> param1; !null, !null -> param1")
-  public <T> T isDeepEquals(T object, Object otherObject) {
-    return isDeepEquals(object, otherObject, "objects must be deeply equal");
+  public <T> T deepEqualTo(T object, Object otherObject) {
+    return deepEqualTo(object, otherObject, "objects must be deeply equal");
   }
 
   /**
@@ -237,13 +237,13 @@ public enum EnsureObjectOps {
    * @param exceptionMessage the message to include in the exception if validation fails
    * @return the first object if they are deeply equal
    * @throws EnsureException if the objects are not deeply equal, with the provided message
-   * @see #isDeepEquals(Object, Object)
-   * @see #isDeepEquals(Object, Object, Supplier)
+   * @see #deepEqualTo(Object, Object)
+   * @see #deepEqualTo(Object, Object, Supplier)
    */
   @Contract(
       "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
-  public <T> T isDeepEquals(T object, Object otherObject, String exceptionMessage) {
-    return isDeepEquals(object, otherObject, () -> EnsureException.of(exceptionMessage));
+  public <T> T deepEqualTo(T object, Object otherObject, String exceptionMessage) {
+    return deepEqualTo(object, otherObject, () -> EnsureException.of(exceptionMessage));
   }
 
   /**
@@ -257,12 +257,12 @@ public enum EnsureObjectOps {
    * @return the first object if they are deeply equal
    * @throws RuntimeException if the objects are not deeply equal; the thrown exception is provided
    *     by {@code exceptionSupplier}
-   * @see #isDeepEquals(Object, Object)
-   * @see #isDeepEquals(Object, Object, String)
+   * @see #deepEqualTo(Object, Object)
+   * @see #deepEqualTo(Object, Object, String)
    */
   @Contract(
       "null, !null, _ -> fail; !null, null, _ -> fail; null, null, _ -> param1; !null, !null, _ -> param1")
-  public <T> T isDeepEquals(
+  public <T> T deepEqualTo(
       T object, Object otherObject, Supplier<? extends RuntimeException> exceptionSupplier) {
     final boolean eq = Objects.deepEquals(object, otherObject);
     if (eq) {

--- a/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureArrayOpsTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureArrayOpsTest.java
@@ -20,7 +20,7 @@ class EnsureArrayOpsTest implements EnsureOpsTest<EnsureArrayOps> {
 
   @Override
   public long expectedPublicMethodCount() {
-    return 5;
+    return 11;
   }
 
   @Test
@@ -41,5 +41,61 @@ class EnsureArrayOpsTest implements EnsureOpsTest<EnsureArrayOps> {
   @Test
   void notEmptyNullFailure() {
     assertThatThrownBy(() -> instance().notEmpty(null)).isInstanceOf(EnsureException.class);
+  }
+
+  @Test
+  void equalToSuccess() {
+    String[] val1 = {"test"};
+    String[] val2 = {"test"};
+    String[] result = instance().equalTo(val1, val2);
+    assertThat(result).isSameAs(val1);
+  }
+
+  @Test
+  void equalToFailure() {
+    String[] val1 = {"test"};
+    String[] val2 = {"not equal"}; // different instance, same content
+    assertThatThrownBy(() -> instance().equalTo(val1, val2))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("arrays must be equal");
+  }
+
+  @Test
+  void deepEqualToSuccess() {
+    Object[] val1 = {new int[] {1, 2}};
+    Object[] val2 = {new int[] {1, 2}};
+    Object[] result = instance().deepEqualTo(val1, val2);
+    assertThat(result).isSameAs(val1);
+  }
+
+  @Test
+  void deepEqualToFailure() {
+    String[] val1 = {"test"};
+    String[] val2 = {"other"};
+    assertThatThrownBy(() -> instance().deepEqualTo(val1, val2))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("arrays must be deeply equal");
+  }
+
+  @Test
+  void deepEqualToCustomMessage() {
+    String[] val1 = {"test"};
+    String[] val2 = {"other"};
+    assertThatThrownBy(() -> instance().deepEqualTo(val1, val2, "custom message"))
+        .isInstanceOf(EnsureException.class)
+        .hasMessage("custom message");
+  }
+
+  @Test
+  void deepEqualToCustomException() {
+    String[] val1 = {"test"};
+    String[] val2 = {"other"};
+    assertThatThrownBy(
+            () ->
+                instance()
+                    .deepEqualTo(
+                        val1, val2, () -> new IllegalArgumentException("custom exception")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("custom exception");
   }
 }

--- a/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureObjectOpsTest.java
+++ b/lib/src/test/java/io/github/mangila/ensure4j/ops/EnsureObjectOpsTest.java
@@ -24,39 +24,39 @@ class EnsureObjectOpsTest implements EnsureOpsTest<EnsureObjectOps> {
   }
 
   @Test
-  void isDeepEqualsSuccess() {
+  void deepEqualToSuccess() {
     String[] val1 = {"test"};
     String[] val2 = {"test"};
-    String[] result = instance().isDeepEquals(val1, val2);
+    String[] result = instance().deepEqualTo(val1, val2);
     assertThat(result).isEqualTo(val1);
   }
 
   @Test
-  void isDeepEqualsFailure() {
+  void deepEqualToFailure() {
     String[] val1 = {"test"};
     String[] val2 = {"other"};
-    assertThatThrownBy(() -> instance().isDeepEquals(val1, val2))
+    assertThatThrownBy(() -> instance().deepEqualTo(val1, val2))
         .isInstanceOf(EnsureException.class)
         .hasMessage("objects must be deeply equal");
   }
 
   @Test
-  void isDeepEqualsCustomMessage() {
+  void deepEqualToCustomMessage() {
     String[] val1 = {"test"};
     String[] val2 = {"other"};
-    assertThatThrownBy(() -> instance().isDeepEquals(val1, val2, "custom message"))
+    assertThatThrownBy(() -> instance().deepEqualTo(val1, val2, "custom message"))
         .isInstanceOf(EnsureException.class)
         .hasMessage("custom message");
   }
 
   @Test
-  void isDeepEqualsCustomException() {
+  void deepEqualToCustomException() {
     String[] val1 = {"test"};
     String[] val2 = {"other"};
     assertThatThrownBy(
             () ->
                 instance()
-                    .isDeepEquals(
+                    .deepEqualTo(
                         val1, val2, () -> new IllegalArgumentException("custom exception")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("custom exception");


### PR DESCRIPTION
- Introduced `equalTo` and `deepEqualTo` methods in `EnsureArrayOps` for validating array equality and deep equality.
- Added overloads with custom exception messages and suppliers.
- Updated `EnsureObjectOps` to align method names with `EnsureArrayOps`.
- Extended `EnsureArrayOpsTest` and `EnsureObjectOpsTest` with comprehensive test cases.
- Updated expected public method count for `EnsureArrayOps`.